### PR TITLE
chore: remove go tidy check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN go mod download
 RUN go mod verify
 COPY ./ ./
 RUN go list -mod=readonly all >/dev/null
-RUN ! go mod tidy -v 2>&1 | grep .
 
 FROM build AS manifests-build
 ARG NAME


### PR DESCRIPTION
This PR removes the go tidy check from the Dockerfile, as it's no longer needed and breaks unexpectedly.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>